### PR TITLE
[sql/GetFirst] fix issues/7

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -1,7 +1,5 @@
 package db
 
-import "fmt"
-
 // Inormational Error constants. Used during a return ... errors.New()
 const (
 	notAMap         = "target object is not a map"
@@ -13,7 +11,3 @@ const (
 	arrayOutOfRange = "index value (%s) is bigger than the length (%s) of the array to be indexed"
 	invalidKeyPath  = "the key||path [%s] that was given is not valid"
 )
-
-func errString(b, k string) string {
-	return fmt.Sprintf(b, k)
-}

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -17,7 +18,7 @@ func getIndex(k string) (int, error) {
 		}
 		return intVar, nil
 	}
-	return 0, errors.New(errString(notAnIndex, k))
+	return 0, errors.New(fmt.Sprintf(notAnIndex, k))
 }
 
 // Some common objects
@@ -130,7 +131,7 @@ func fileExists(filepath string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	} else if f.IsDir() {
-		return false, errors.New(errString(dictNotFile, filepath))
+		return false, errors.New(fmt.Sprintf(dictNotFile, filepath))
 	}
 
 	return true, nil

--- a/db/storage.go
+++ b/db/storage.go
@@ -13,7 +13,7 @@ import (
 // state yaml file
 type Storage struct {
 	sync.Mutex
-	SQL  SQL
+	SQL  *SQL
 	Data interface{}
 	Path string
 }
@@ -21,7 +21,7 @@ type Storage struct {
 // NewStorageFactory for creating a new Storage struct.
 func NewStorageFactory(path string) (*Storage, error) {
 	state := &Storage{
-		SQL:  SQL{},
+		SQL:  NewSQLFactory(),
 		Path: path,
 	}
 

--- a/db/wrappers.go
+++ b/db/wrappers.go
@@ -8,7 +8,7 @@ import (
 
 // Upsert is a SQL wrapper for adding/updating map structures
 func (s *Storage) Upsert(k string, i interface{}) error {
-	err := s.SQL.upsert(k, i, s.Data)
+	err := s.SQL.upsertRecursive(strings.Split(k, "."), s.Data, i)
 	if err != nil {
 		return errors.Wrap(err, "Upsert")
 	}


### PR DESCRIPTION
In this commit we fixed the GetFirst Method which
was exporting a different value when a branch with
the queried key in lower hierarchy was processed
first

In addition to that change, we made the following
changes:

- Updated Upsert wrapper to use directly upsertRecursive
- Exported Cache content
- SQL Now is a Pointer to Storage struct
- Minor changes e.g. remove redundant error function