### PR TITLE
[errors] include caller or error wrap

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -1,5 +1,11 @@
 package db
 
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
 // Inormational Error constants. Used during a return ... errors.New()
 const (
 	notAMap         = "target object is not a map"
@@ -11,3 +17,17 @@ const (
 	arrayOutOfRange = "index value (%s) is bigger than the length (%s) of the array to be indexed"
 	invalidKeyPath  = "the key||path [%s] that was given is not valid"
 )
+
+func wrapErr(e error, s string) error {
+	if s == "" {
+		return e
+	}
+
+	return errors.Wrap(
+		e,
+		strings.Split(
+			s,
+			"/",
+		)[len(strings.Split(s, "/"))-1],
+	)
+}

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -3,6 +3,7 @@ package db
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -10,15 +11,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func getFn() string {
+	pc, _, no, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		return fmt.Sprintf("%s#%s", details.Name(), strconv.Itoa(no))
+	}
+	return ""
+}
+
 func getIndex(k string) (int, error) {
 	if strings.HasPrefix(k, "[") && strings.HasSuffix(k, "]") {
 		intVar, err := strconv.Atoi(k[1 : len(k)-1])
 		if err != nil {
-			return 0, errors.Wrap(err, "getIndex")
+			return 0, wrapErr(err, getFn())
 		}
 		return intVar, nil
 	}
-	return 0, errors.New(fmt.Sprintf(notAnIndex, k))
+	return 0, wrapErr(fmt.Errorf(notAnIndex, k), getFn())
 }
 
 // Some common objects
@@ -79,19 +89,19 @@ func getObjectType(o interface{}) objectType {
 func copyMap(o interface{}) (interface{}, error) {
 	obj, err := interfaceToMap(o)
 	if err != nil {
-		return nil, errors.Wrap(err, "copyMap")
+		return nil, wrapErr(err, getFn())
 	}
 
 	var cache interface{}
 
 	data, err := yaml.Marshal(&obj)
 	if err != nil {
-		return nil, errors.Wrap(err, "copyMap")
+		return nil, wrapErr(err, getFn())
 	}
 
 	err = yaml.Unmarshal(data, &cache)
 	if err != nil {
-		return nil, errors.Wrap(err, "copyMap")
+		return nil, wrapErr(err, getFn())
 	}
 
 	return cache, nil
@@ -101,7 +111,7 @@ func interfaceToMap(o interface{}) (map[interface{}]interface{}, error) {
 	obj, isMap := o.(map[interface{}]interface{})
 	if !isMap {
 		if o != nil {
-			return nil, errors.Wrap(errors.New(notAMap), "interfaceToMap")
+			return nil, wrapErr(errors.New(notAMap), getFn())
 		}
 		obj = make(map[interface{}]interface{})
 	}
@@ -119,7 +129,7 @@ func makeDirs(p string, m os.FileMode) error {
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		err = os.MkdirAll(p, m)
 		if err != nil {
-			return errors.Wrap(err, "makeDirs")
+			return wrapErr(err, getFn())
 		}
 	}
 	return nil
@@ -131,7 +141,7 @@ func fileExists(filepath string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	} else if f.IsDir() {
-		return false, errors.New(fmt.Sprintf(dictNotFile, filepath))
+		return false, wrapErr(fmt.Errorf(dictNotFile, filepath), getFn())
 	}
 
 	return true, nil

--- a/db/wrappers.go
+++ b/db/wrappers.go
@@ -2,15 +2,13 @@ package db
 
 import (
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Upsert is a SQL wrapper for adding/updating map structures
 func (s *Storage) Upsert(k string, i interface{}) error {
 	err := s.SQL.upsertRecursive(strings.Split(k, "."), s.Data, i)
 	if err != nil {
-		return errors.Wrap(err, "Upsert")
+		return wrapErr(err, getFn())
 	}
 
 	return s.stateReload()
@@ -22,7 +20,7 @@ func (s *Storage) Upsert(k string, i interface{}) error {
 func (s *Storage) GetFirst(k string) (interface{}, error) {
 	obj, err := s.SQL.getFirst(k, s.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "GetFirst")
+		return nil, wrapErr(err, getFn())
 	}
 
 	return obj, nil
@@ -41,7 +39,7 @@ func (s *Storage) GetFirst(k string) (interface{}, error) {
 func (s *Storage) Get(k string) ([]string, error) {
 	obj, err := s.SQL.get(k, s.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "Get")
+		return nil, wrapErr(err, getFn())
 	}
 
 	return obj, nil
@@ -58,7 +56,7 @@ func (s *Storage) GetPath(k string) (interface{}, error) {
 	keys := strings.Split(k, ".")
 	obj, err := s.SQL.getPath(keys, s.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "GetPath")
+		return nil, wrapErr(err, getFn())
 	}
 
 	return obj, nil
@@ -71,7 +69,7 @@ func (s *Storage) GetPath(k string) (interface{}, error) {
 func (s *Storage) Delete(k string) error {
 	err := s.SQL.delPath(k, s.Data)
 	if err != nil {
-		return errors.Wrap(err, "Delete")
+		return wrapErr(err, getFn())
 	}
 
 	return s.Write()
@@ -82,7 +80,7 @@ func (s *Storage) Delete(k string) error {
 func (s *Storage) MergeDBs(path string) error {
 	err := s.SQL.mergeDBs(path, s.Data)
 	if err != nil {
-		return errors.Wrap(err, "MergeDBs")
+		return wrapErr(err, getFn())
 	}
 
 	return s.Write()


### PR DESCRIPTION
Before we were wrapping errors by adding
manually the callers name

Now we wrapp errors by getting automatically
the callers name and line of code