### PR TITLE
fix: [getFirst] codition was using wrong indexes

### DIFF
--- a/db/helpers.go
+++ b/db/helpers.go
@@ -15,7 +15,7 @@ func getFn() string {
 	pc, _, no, ok := runtime.Caller(1)
 	details := runtime.FuncForPC(pc)
 	if ok && details != nil {
-		return fmt.Sprintf("%s#%s", details.Name(), strconv.Itoa(no))
+		return fmt.Sprintf("%s#%s\n", details.Name(), strconv.Itoa(no))
 	}
 	return ""
 }

--- a/db/sql.go
+++ b/db/sql.go
@@ -14,9 +14,9 @@ import (
 // v1 & v2 are common interface{} placeholders while keys is used by
 // path discovery methods to keep track and derive the right path.
 type Cache struct {
-	V1   interface{}
-	V2   int
-	Keys []string
+	V1, V2     interface{}
+	C1, C2, C3 int
+	Keys       []string
 }
 
 // Query hosts results from SQL methods
@@ -241,19 +241,18 @@ func (d *SQL) getFirst(k string, o interface{}) (interface{}, error) {
 		return nil, wrapErr(fmt.Errorf(keyDoesNotExist, k), getFn())
 	}
 
+	d.Cache.C1 = len(strings.Split(obj[0], "."))
 	if len(obj) == 1 {
 		return d.getPath(strings.Split(obj[0], "."), o)
 	}
-
-	for i, key := range obj[1:] {
-		d.dropKeys()
-		if len(strings.Split(key, ".")) < len(strings.Split(obj[0], ".")) {
-			d.dropKeys()
-			d.Cache.V2 = i
+	for i, key := range obj {
+		if len(strings.Split(key, ".")) < d.Cache.C1 {
+			d.Cache.C1 = len(strings.Split(key, "."))
+			d.Cache.C2 = i
 		}
 	}
 
-	return d.getPath(strings.Split(obj[d.Cache.V2], "."), o)
+	return d.getPath(strings.Split(obj[d.Cache.C2], "."), o)
 }
 
 func (d *SQL) upsertRecursive(k []string, o, v interface{}) error {

--- a/db/wrappers.go
+++ b/db/wrappers.go
@@ -30,11 +30,12 @@ func (s *Storage) GetFirst(k string) (interface{}, error) {
 // e.g. ["key-1.test", "key-2.key-3.test"] will be returned
 // if "test" was the key asked from the following yaml
 // ---------
+//
 // key-1:
-//	test: someValue-1
+//		test: someValue-1
 // key-2:
-//	key-3:
-//		test: someValue-2
+//		key-3:
+//			test: someValue-2
 //
 func (s *Storage) Get(k string) ([]string, error) {
 	obj, err := s.SQL.get(k, s.Data)

--- a/sql_test.go
+++ b/sql_test.go
@@ -165,8 +165,8 @@ func TestGetSingle(t *testing.T) {
 	err = state.Upsert(
 		"path-1",
 		map[string][]string{
-			"key-3": {"value-1"},
-			"key-4": {"value-2"},
+			"key-3": {"value-3"},
+			"key-4": {"value-4"},
 		},
 	)
 
@@ -174,11 +174,25 @@ func TestGetSingle(t *testing.T) {
 
 	val, err = state.GetFirst("key-3")
 	assert.Equal(t, err, nil)
-	assert.Equal(t, val, []interface{}{"value-1"})
+	assert.Equal(t, val, []interface{}{"value-3"})
 
 	val, err = state.GetFirst("key-4")
 	assert.Equal(t, err, nil)
-	assert.Equal(t, val, []interface{}{"value-2"})
+	assert.Equal(t, val, []interface{}{"value-4"})
+	err = state.Upsert(
+		"key-3",
+		map[string][]string{
+			"key-5": {"value-5"},
+			"key-6": {"value-6"},
+		},
+	)
+
+	assert.Equal(t, err, nil)
+
+	val, err = state.GetFirst("key-3")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val.(map[interface{}]interface{})["key-5"].([]interface{})[0], "value-5")
+	assert.Equal(t, val.(map[interface{}]interface{})["key-6"].([]interface{})[0], "value-6")
 
 	err = os.Remove(path)
 	assert.Equal(t, err, nil)


### PR DESCRIPTION
The issue was due to a missconfigured test.
The value expected value from 2 different
scenarios was the same.

That lead assert to pass both scenarions
while it should have faild on the second

Now tests have been updated and the wrong
condition that was returning a wrong value
fixed