### PR TITLE
improvement: block empty keys

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -16,6 +16,7 @@ const (
 	notAnIndex      = "object (%s) is not an index. Index example: some.path.[someInteger].someKey"
 	arrayOutOfRange = "index value (%s) is bigger than the length (%s) of the array to be indexed"
 	invalidKeyPath  = "the key||path [%s] that was given is not valid"
+	emptyKey        = "path [%s] contains an empty key"
 )
 
 func wrapErr(e error, s string) error {

--- a/db/utils.go
+++ b/db/utils.go
@@ -11,6 +11,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func checkKeyPath(k []string) error {
+	for _, j := range k {
+		if j == "" {
+			return fmt.Errorf(emptyKey, strings.Join(k, "."))
+		}
+	}
+	return nil
+}
+
 func getFn() string {
 	pc, _, no, ok := runtime.Caller(1)
 	details := runtime.FuncForPC(pc)

--- a/sql_test.go
+++ b/sql_test.go
@@ -145,7 +145,7 @@ func TestGetSingle(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	err = state.Upsert(
-		".test.path",
+		"test.path",
 		map[string]string{
 			"key-1": "value-1",
 			"key-2": "value-2",


### PR DESCRIPTION
In this commit we block empty keys from inputs

Empty key can be either a direct query with ""
or a path query e.g. str1..str2.str3

In the above example, after str1 we have a double
dot. The methods currently split keys with dot
delimeter before a search is initiated.

Note: While the algorithm works with dots also,
it makes no sense to allow empty keys as part
of map content