### PR TITLE
include convert-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 main.go
 local
 ops
+test.*
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Table of Contents
         - [Without trailing array](#without-trailing-array)
         - [With trailing array](#with-trailing-array)
     * [Delete Key By Path](#delete-key-by-path)
+	* [Convert Utils](#convert-utils)
+      + [Get map of strings from interface](#get-map-of-strings-from-interface)
+        - [Get map directly from a GetPath object](#get-map-directly-from-a-getpath-object)
+		- [Get map manually](#get-map-manually)
+	  + [Get array of string from interface](#get-array-of-string-from-interface)
+        - [Get array directly from a GetPath object](#get-array-directly-from-a-getpath-object)
+		- [Get array manually](#get-array-manually)
 
 ## Features
 
@@ -193,4 +200,135 @@ err = state.Delete("key-1.key-2")
 if err != nil {
 	logger.Fatalf(err.Error())
 }
+```
+
+### Convert Utils
+
+Convert simply automate the need to
+explicitly do assertion each time we need to access
+an interface object.
+
+Let us assume we have the following YAML structure
+
+```yaml
+
+to:
+  array-1:
+    key-1:
+    - key-2: 2
+    - key-3: 3
+    - key-4: 4
+  array-2:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  array-3:
+  - key-1: 1
+  - key-2: 2
+
+```
+
+#### Get map of strings from interface
+
+We can do this in two ways, get object by giving a path and assert the interface to `map[string]string`, or work manually our way to the object
+
+##### Get map directly from a GetPath object
+
+To get map **key-2: 2**, first get object via GetPath
+
+```go
+
+obj, err := state.GetPath("to.array-1.key-1.[0]")
+if err != nil {
+	logger.Fatalf(err.Error())
+}
+logger.Info(val)
+
+```
+
+Next, assert **obj** as `map[string]string`
+
+```go
+
+assertData := db.NewConvertFactory()
+
+assertData.Input(val)
+if assertData.Error != nil {
+	logger.Fatalf(assertData.Error.Error())
+}
+vMap := assertData.GetMap()
+logger.Info(vMap["key-2"])
+
+```
+
+##### Get map manually
+
+We can get the map manually by using only **Convert** operations
+
+```go
+
+assertData := db.NewConvertFactory()
+
+assertData.Input(state.Data).
+	Key("to").
+	Key("array-1").
+	Key("key-1").Index(0)
+if assertData.Error != nil {
+	logger.Fatalf(assertData.Error.Error())
+}
+vMap := assertData.GetMap()
+logger.Info(vMap["key-2"])
+
+```
+
+#### Get array of string from interface
+
+Again here we can do it two ways as with the map example
+
+##### Get array directly from a GetPath object
+
+To get **array-2** as **[]string**, first get object via GetPath
+
+```go
+
+obj, err = state.GetPath("to.array-2")
+if err != nil {
+	logger.Fatalf(err.Error())
+}
+logger.Info(obj)
+
+```
+
+Next, assert **obj** as `[]string`
+
+```go
+
+assertData := db.NewConvertFactory()
+
+assertData.Input(obj)
+if assertData.Error != nil {
+	logger.Fatalf(assertData.Error.Error())
+}
+vArray := assertData.GetArray()
+logger.Info(vArray)
+
+```
+
+##### Get array manually
+
+We can get the array manually by using only **Convert** operations
+
+```go
+
+assertData.Input(state.Data).
+	Key("to").
+	Key("array-2")
+if assertData.Error != nil {
+	logger.Fatalf(assertData.Error.Error())
+}
+vArray := assertData.GetArray()
+logger.Info(vArray)
+
 ```

--- a/db/cache.go
+++ b/db/cache.go
@@ -6,16 +6,32 @@ package db
 // to keep track and derive the right path.
 type Cache struct {
 	V1, V2     interface{}
+	V3         []interface{}
+	B          []byte
+	E          error
 	C1, C2, C3 int
 	Keys       []string
+}
+
+// NewCacheFactory for creating a new Cache
+func NewCacheFactory() Cache {
+	cache := Cache{
+		V3:   make([]interface{}, 0),
+		B:    make([]byte, 0),
+		Keys: make([]string, 0),
+	}
+	return cache
 }
 
 // Clear for clearing the cache and setting all
 // content to nil
 func (c *Cache) Clear() *Cache {
 	c.V1, c.V2 = nil, nil
+	c.V3 = make([]interface{}, 0)
 	c.C1, c.C2, c.C3 = 0, 0, 0
-	c.Keys = nil
+	c.B = make([]byte, 0)
+	c.E = nil
+	c.Keys = make([]string, 0)
 
 	return c
 }

--- a/db/constants.go
+++ b/db/constants.go
@@ -27,5 +27,10 @@ func getObjectType(o interface{}) objectType {
 		return 2
 	}
 
+	_, isMapStringInterface := o.(map[string]interface{})
+	if isMapStringInterface {
+		return 5
+	}
+
 	return unknownObj
 }

--- a/db/convert.go
+++ b/db/convert.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// AssertData is used to for converting interface objects to
+// map of interfaces or array of interfaces
+type AssertData struct {
+	D0    map[string]string
+	A0    []string
+	Error error
+	Cache Cache
+}
+
+// NewConvertFactory for initializing AssertData
+func NewConvertFactory() *AssertData {
+	assertData := &AssertData{
+		D0:    make(map[string]string),
+		A0:    make([]string, 0),
+		Cache: NewCacheFactory(),
+	}
+	return assertData
+}
+
+// Clear for resetting AssertData
+func (s *AssertData) Clear() {
+	s.Cache.Clear()
+	s.D0 = make(map[string]string)
+	s.A0 = make([]string, 0)
+}
+
+// Input sets a data source that can be used for assertion
+func (s *AssertData) Input(o interface{}) *AssertData {
+	s.Clear()
+	s.Cache.V1 = o
+	return s
+}
+
+func (s *AssertData) toBytes() {
+	s.Cache.B, s.Cache.E = yaml.Marshal(s.Cache.V1)
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+	}
+}
+
+// GetMap for converting a map[interface{}]interface{} into a map[string]string
+func (s *AssertData) GetMap() map[string]string {
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return nil
+	}
+
+	s.toBytes()
+	if s.Cache.E != nil {
+		return nil
+	}
+
+	s.Cache.E = yaml.Unmarshal(s.Cache.B, &s.D0)
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return nil
+	}
+	return s.D0
+}
+
+// GetArray for converting a []interface{} to []string
+func (s *AssertData) GetArray() []string {
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return nil
+	}
+
+	_, isArray := s.Cache.V1.([]interface{})
+	if !isArray {
+		s.Cache.E = wrapErr(fmt.Errorf(notArrayObj), getFn())
+		s.Error = s.Cache.E
+		return nil
+	}
+
+	s.toBytes()
+	if s.Cache.E != nil {
+		return nil
+	}
+
+	s.Cache.E = yaml.Unmarshal(s.Cache.B, &s.A0)
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return nil
+	}
+
+	return s.A0
+}
+
+// Key copies initial interface object and returns a map of interfaces{}
+// Used to easily pipe interfaces
+func (s *AssertData) Key(k string) *AssertData {
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return s
+	}
+
+	_, isMap := s.Cache.V1.(map[interface{}]interface{})
+	if !isMap {
+		s.Cache.E = wrapErr(fmt.Errorf(notAMap), getFn())
+		s.Error = s.Cache.E
+		return s
+	}
+
+	s.Cache.V1 = s.Cache.V1.(map[interface{}]interface{})[k]
+
+	return s
+}
+
+// Index getting an interface{} from a []interface{}
+func (s *AssertData) Index(i int) *AssertData {
+	if s.Cache.E != nil {
+		s.Error = s.Cache.E
+		return s
+	}
+
+	_, isArray := s.Cache.V1.([]interface{})
+	if !isArray {
+		s.Cache.E = wrapErr(fmt.Errorf(notArrayObj), getFn())
+		s.Error = s.Cache.E
+		return s
+	}
+	s.Cache.V1 = s.Cache.V1.([]interface{})[i]
+
+	return s
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -136,8 +136,8 @@ func TestUpsert(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
-// TestGetSingle run unit tests on GetSingle key
-func TestGetSingle(t *testing.T) {
+// TestGetFirst run unit tests on GetSingle key
+func TestGetFirst(t *testing.T) {
 	t.Parallel()
 
 	path := ".test/db-query.yaml"
@@ -193,6 +193,37 @@ func TestGetSingle(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, val.(map[interface{}]interface{})["key-5"].([]interface{})[0], "value-5")
 	assert.Equal(t, val.(map[interface{}]interface{})["key-6"].([]interface{})[0], "value-6")
+
+	err = state.Upsert(
+		"test",
+		map[string]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = state.Upsert(
+		"key-3",
+		map[string][]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = state.Upsert(
+		"path-1",
+		map[string][]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = state.Upsert(
+		"to.array-10",
+		map[string][]map[string]int{
+			"key-10": {
+				{"key-20": 20},
+				{"key-30": 30},
+				{"key-40": 40},
+			},
+		},
+	)
+	assert.Equal(t, err, nil)
+
+	val, err = state.GetFirst("key-30")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, 30)
 
 	err = os.Remove(path)
 	assert.Equal(t, err, nil)


### PR DESCRIPTION
Convert utils for converting interfaces to
- map[string]string
- []string

This is a helper util for
quickly accessing the Memory Data

Before:
	We could get with GetFirst, GetPath
	the objects with an interface type

Now:
	We can use convert utils to either
	to get a map or array from interfaces
	quickly