### PR TITLE
fixes: [docs/convert] methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,13 @@ Next, assert **obj** as `map[string]string`
 assertData := db.NewConvertFactory()
 
 assertData.Input(val)
-if assertData.Error != nil {
-	logger.Fatalf(assertData.Error.Error())
+if assertData.GetError() != nil {
+	logger.Fatal(assertData.GetError())
 }
-vMap := assertData.GetMap()
+vMap, err := assertData.GetMap()
+if err != nil {
+	logger.Fatal(err)
+}
 logger.Info(vMap["key-2"])
 
 ```
@@ -285,10 +288,13 @@ assertData.Input(state.Data).
 	Key("to").
 	Key("array-1").
 	Key("key-1").Index(0)
-if assertData.Error != nil {
-	logger.Fatalf(assertData.Error.Error())
+if assertData.GetError() != nil {
+	logger.Fatal(assertData.GetError())
 }
-vMap := assertData.GetMap()
+vMap, err := assertData.GetMap()
+if err != nil {
+	logger.Fatal(err)
+}
 logger.Info(vMap["key-2"])
 
 ```
@@ -318,10 +324,13 @@ Next, assert **obj** as `[]string`
 assertData := db.NewConvertFactory()
 
 assertData.Input(obj)
-if assertData.Error != nil {
-	logger.Fatalf(assertData.Error.Error())
+if assertData.GetError() != nil {
+	logger.Fatal(assertData.GetError())
 }
-vArray := assertData.GetArray()
+vArray, err := assertData.GetArray()
+if err != nil {
+	logger.Fatal(err)
+}
 logger.Info(vArray)
 
 ```
@@ -335,10 +344,13 @@ We can get the array manually by using only **Convert** operations
 assertData.Input(state.Data).
 	Key("to").
 	Key("array-2")
-if assertData.Error != nil {
-	logger.Fatalf(assertData.Error.Error())
+if assertData.GetError() != nil {
+	logger.Fatal(assertData.GetError())
 }
-vArray := assertData.GetArray()
+vArray, err := assertData.GetArray()
+if err != nil {
+	logger.Fatal(err)
+}
 logger.Info(vArray)
 
 ```

--- a/db/cache.go
+++ b/db/cache.go
@@ -23,6 +23,11 @@ func NewCacheFactory() Cache {
 	return cache
 }
 
+// GetError returns cache error field
+func (c *Cache) GetError() error {
+	return c.E
+}
+
 // Clear for clearing the cache and setting all
 // content to nil
 func (c *Cache) Clear() *Cache {

--- a/db/errors.go
+++ b/db/errors.go
@@ -20,6 +20,7 @@ const (
 	libOutOfIndex   = "lib out of index"
 	docNotExists    = "doc [%s] does not exist in lib"
 	fieldNotString  = "[%s] with value [%s] is not a string"
+	notAType        = "value is not a %s"
 )
 
 func wrapErr(e error, s string) error {

--- a/db/storage.go
+++ b/db/storage.go
@@ -120,7 +120,7 @@ func (s *Storage) Switch(i int) error {
 // AddDoc will add a new document to the stack and will switch
 // Active Document index to that document
 func (s *Storage) AddDoc() error {
-	s.AD++
+	s.AD = len(s.Data)
 	s.Data = append(s.Data, make(map[interface{}]interface{}))
 	return s.stateReload()
 }
@@ -198,14 +198,12 @@ func (s *Storage) Read() error {
 	s.Data = nil
 	s.Data = make([]interface{}, 0)
 
-	var counter int
 	var data interface{}
 	dec := yaml.NewDecoder(bytes.NewReader(f))
 	for {
-		s.Data = append(s.Data, data)
-		err := dec.Decode(&s.Data[counter])
+		err := dec.Decode(&data)
 		if err == nil {
-			counter++
+			s.Data = append(s.Data, data)
 			data = nil
 			continue
 		}
@@ -235,8 +233,6 @@ func (s *Storage) Write() error {
 
 	for _, j := range s.Data {
 		if j == nil {
-			continue
-		} else if v, ok := j.(map[interface{}]interface{}); ok && len(v) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
### Features
    
- Cache.GetError: "Method for returning Cache.E"
- Convert: "New methods GetString, GetInt, GetError"

### Fixes:

- Storage.AddDoc: "Now switches to the correct index after adding a new doc"
- Storage.Read: "No longer creates nil docs on read"
- Storage.Write: "No longer skips empty maps"

### Tests:

- MultiDoc: "Tests for checking doc switch & add"