### PR TITLE
feat: [storage] support in memory only operations

### DIFF
--- a/cache/v1/v1.go
+++ b/cache/v1/v1.go
@@ -1,4 +1,4 @@
-package db
+package v1
 
 // Cache for easily sharing state between map operations and methods
 // V{1,2} are common interface{} placeholders, C{1,2,3} are counters used
@@ -30,23 +30,33 @@ func (c *Cache) GetError() error {
 
 // Clear for clearing the cache and setting all
 // content to nil
-func (c *Cache) Clear() *Cache {
+func (c *Cache) Clear() {
 	c.V1, c.V2 = nil, nil
 	c.V3 = make([]interface{}, 0)
 	c.C1, c.C2, c.C3 = 0, 0, 0
 	c.B = make([]byte, 0)
 	c.E = nil
 	c.Keys = make([]string, 0)
-
-	return c
 }
 
-func (c *Cache) dropLastKey() {
+// DropLastKey removes the last key added from the list
+func (c *Cache) DropLastKey() {
 	if len(c.Keys) > 0 {
 		c.Keys = c.Keys[:len(c.Keys)-1]
 	}
 }
 
-func (c *Cache) dropKeys() {
-	c.Keys = nil
+// DropKeys removes all keys from the list
+func (c *Cache) DropKeys() {
+	c.Keys = make([]string, 0)
+}
+
+// AddKey for appending a new Key to cache
+func (c *Cache) AddKey(k string) {
+	c.Keys = append(c.Keys, k)
+}
+
+// GetKeys returns Cache.Keys
+func (c *Cache) GetKeys() []string {
+	return c.Keys
 }

--- a/cache/v2/v2.go
+++ b/cache/v2/v2.go
@@ -1,0 +1,31 @@
+package v1
+
+// Cache hosts results from SQL methods
+type Cache struct {
+	KeysFound []string
+	Results   interface{}
+}
+
+// NewCacheFactory for creating a new Cache
+func NewCacheFactory() Cache {
+	cache := Cache{
+		KeysFound: make([]string, 0),
+	}
+	return cache
+}
+
+// Clear for clearing the cache
+func (c *Cache) Clear() {
+	c.Results = nil
+	c.KeysFound = make([]string, 0)
+}
+
+// AddKey for appending a new Key to cache
+func (c *Cache) AddKey(k string) {
+	c.KeysFound = append(c.KeysFound, k)
+}
+
+// GetKeys returns Cache.KeysFound
+func (c *Cache) GetKeys() []string {
+	return c.KeysFound
+}

--- a/cache/v3/v3.go
+++ b/cache/v3/v3.go
@@ -1,0 +1,1 @@
+package v3

--- a/db/constants.go
+++ b/db/constants.go
@@ -1,5 +1,7 @@
 package db
 
+import "fmt"
+
 type objectType int
 
 const (
@@ -16,7 +18,7 @@ const (
 	arrayMapStringArrayInterface
 )
 
-// Inormational Error constants. Used during a return err
+// Informational Error constants. Used during a return err
 const (
 	notAMap         = "target object is not a map"
 	notArrayObj     = "received a non array object but expected []interface{}"
@@ -32,6 +34,16 @@ const (
 	fieldNotString  = "[%s] with value [%s] is not a string"
 	notAType        = "value is not a %s"
 )
+
+// Warnings
+const (
+	deprecatedFeature = "Warn: Deprecated is [%s]. Will be replaced by [%s] in the future"
+)
+
+func issueWarning(s string, o ...interface{}) {
+	warn := fmt.Sprintf(s, o...)
+	fmt.Println(warn)
+}
 
 func getObjectType(o interface{}) objectType {
 	_, isMap := o.(map[interface{}]interface{})

--- a/db/convert.go
+++ b/db/convert.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	v1 "github.com/ulfox/dby/cache/v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -12,7 +13,7 @@ type AssertData struct {
 	s1    []string
 	i0    *int
 	i1    []int
-	cache Cache
+	cache v1.Cache
 }
 
 // NewConvertFactory for initializing AssertData
@@ -20,7 +21,7 @@ func NewConvertFactory() *AssertData {
 	ad := &AssertData{
 		d0:    make(map[string]string),
 		s1:    make([]string, 0),
-		cache: NewCacheFactory(),
+		cache: v1.NewCacheFactory(),
 	}
 	return ad
 }

--- a/tests/sql_test.go
+++ b/tests/sql_test.go
@@ -144,6 +144,7 @@ func TestGetFirst(t *testing.T) {
 	path := ".test/db-query.yaml"
 	state, err := db.NewStorageFactory(path)
 	assert.Equal(t, err, nil)
+	state.InMem(true)
 
 	err = state.Upsert(
 		"test.path",
@@ -237,6 +238,7 @@ func TestGetPath(t *testing.T) {
 	path := ".test/db-get-path.yaml"
 	state, err := db.NewStorageFactory(path)
 	assert.Equal(t, err, nil)
+	state.InMem(true)
 
 	err = state.Upsert(
 		"test.path",
@@ -308,6 +310,7 @@ func TestDelete(t *testing.T) {
 	path := ".test/db-delete-key.yaml"
 	state, err := db.NewStorageFactory(path)
 	assert.Equal(t, err, nil)
+	state.InMem(true)
 
 	err = state.Upsert(
 		"test.path",
@@ -342,6 +345,7 @@ func TestGet(t *testing.T) {
 	path := ".test/db-get-keys.yaml"
 	state, err := db.NewStorageFactory(path)
 	assert.Equal(t, err, nil)
+	state.InMem(true)
 
 	err = state.Upsert(
 		"path-1",
@@ -403,6 +407,7 @@ func TestGeneric(t *testing.T) {
 	path := ".test/db-generic.yaml"
 	state, err := db.NewStorageFactory(path)
 	assert.Equal(t, err, nil)
+	state.InMem(true)
 
 	err = state.Upsert(
 		".someKey",
@@ -501,6 +506,7 @@ func TestMultiDoc(t *testing.T) {
 
 	path := ".test/db-multidoc.yaml"
 	state, err := db.NewStorageFactory(path)
+	state.InMem(true)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(state.Data), 1)
 


### PR DESCRIPTION
In this commit we included the InMem method which
when run with true will configure the state manager
method to encode / decode objects only in memory
and never write to storage