### PR TITLE
fix: [findKeys: key depth] [DeleteGlobal]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
         go get -v -t -d ./...
 
     - name: Test
-      run: make test
+      run: make testloop test_loop=100

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ lint:
 
 .PHONY: test
 test: clean
+	@go test -v ./tests/; \
+	rmdir ./tests/.test
+
+.PHONY: testloop
+testloop: clean
 	@set -e; \
 	hasErr=0; \
-	for i in {0..10}; do \
+	for i in $$(seq 0 $${test_loop}); do \
 		go test -v ./tests/; \
 		if [[ "$${?}" != 0 ]]; then \
 			hasErr=1; break; \

--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ We have 2 ways to name our documents
 
 ##### Name documents manually
 
+**Note:** If we use localfile instead of mem only, on read document names are reset. This is done currently to avoid pointer to
+doc missmatches. In the future we will use local state to keep this information between reads. A **Read** is triggered each time
+we run a write (Upsert/Delete) action or when we initialize the db.
+
 To name a document manually, we can use the **SetName** method which takes 2 arguments
 
 - name
@@ -304,6 +308,10 @@ if err != nil {
 ```
 
 ##### Name all documents automatically
+
+**Note:** If we use localfile instead of mem only, on read document names are reset. This is done currently to avoid pointer to
+doc missmatches. In the future we will use local state to keep this information between reads. A **Read** is triggered each time
+we run a write (Upsert/Delete) action or when we initialize the db.
 
 To name all documents automatically we need to ensure that the same path exists in all documents.
 

--- a/cache/v2/v2.go
+++ b/cache/v2/v2.go
@@ -1,29 +1,130 @@
 package v2
 
+import (
+	"strings"
+)
+
 // Query hosts results from SQL methods
 type Query struct {
-	keys []string
+	cache map[int]map[string]map[string]*interface{}
+	first map[int]map[string]string
+	index int
 }
 
 // NewQueryFactory for creating a new Query
 func NewQueryFactory() Query {
 	Query := Query{
-		keys: make([]string, 0),
+		cache: make(map[int]map[string]map[string]*interface{}),
+		first: make(map[int]map[string]string),
 	}
 	return Query
 }
 
-// Clear for clearing the Query
-func (c *Query) Clear() {
-	c.keys = make([]string, 0)
+// UpdateQCache for storing paths for a given key and the related
+// path objects
+func (c *Query) UpdateQCache(path string, o *interface{}) {
+	slicedPath := strings.Split(path, ".")
+	key := slicedPath[len(slicedPath)-1]
+
+	if _, ok := c.cache[c.index][key]; !ok {
+		c.cache[c.index][key] = map[string]*interface{}{
+			path: o,
+		}
+		c.first[c.index][key] = path
+		return
+	}
+
+	c.cache[c.index][key][path] = o
+
+	first := c.first[c.index][key]
+	if len(strings.Split(first, ".")) >= len(slicedPath) {
+		c.first[c.index][key] = path
+	}
 }
 
-// AddKey for appending a new Key to Query
-func (c *Query) AddKey(k string) {
-	c.keys = append(c.keys, k)
+// DeleteQCachePath for removing a path from the Query cache
+func (c *Query) DeleteQCachePath(path string) {
+	slicedPath := strings.Split(path, ".")
+	key := slicedPath[len(slicedPath)-1]
+
+	if _, ok := c.cache[c.index][key]; !ok {
+		return
+	}
+
+	delete(c.cache[c.index][key], path)
+
+	first, ok := c.first[c.index][key]
+	if !ok {
+		return
+	}
+
+	if first == path {
+		delete(c.cache[c.index], key)
+	}
 }
 
-// GetKeys returns Query.KeysFound
-func (c *Query) GetKeys() []string {
-	return c.keys
+// SetQIndex for setting cache index
+func (c *Query) SetQIndex(i int) {
+	c.index = i
+	if _, ok := c.cache[c.index]; !ok {
+		c.cache[c.index] = make(map[string]map[string]*interface{})
+	}
+	if _, ok := c.first[c.index]; !ok {
+		c.first[c.index] = make(map[string]string)
+	}
+}
+
+// GetQCache for returning the Query cache
+func (c *Query) GetQCache(k string) (*map[string]*interface{}, bool) {
+	keys, ok := c.cache[c.index][k]
+	if !ok {
+		return nil, false
+	}
+	return &keys, ok
+}
+
+// GetQCachePath for returning a path for a given key from the Query cache
+func (c *Query) GetQCachePath(path string) (*interface{}, bool) {
+	slicedPath := strings.Split(path, ".")
+	key := slicedPath[len(slicedPath)-1]
+
+	_, ok := c.cache[c.index][key]
+	if !ok {
+		return nil, false
+	}
+
+	obj, ok := c.cache[c.index][key][path]
+	return obj, ok
+}
+
+// KeyExists check if a path exists for a given key
+func (c *Query) KeyExists(path string) bool {
+	slicedPath := strings.Split(path, ".")
+	key := slicedPath[len(slicedPath)-1]
+
+	p, ok := c.cache[c.index][key]
+	if !ok {
+		return false
+	}
+
+	_, ok = p[path]
+	return ok
+}
+
+// FirstKey get the highest order path for a given key
+func (c *Query) FirstKey(k string) (string, *interface{}, bool) {
+	first, ok := c.first[c.index][k]
+	if !ok {
+		return "", nil, false
+	}
+	return first, c.cache[c.index][k][first], true
+}
+
+// QCacheKeys get all keys from Query cache
+func (c *Query) QCacheKeys(k string) []string {
+	var keys []string
+	for i := range c.cache[c.index][k] {
+		keys = append(keys, i)
+	}
+	return keys
 }

--- a/db/state.go
+++ b/db/state.go
@@ -11,7 +11,7 @@ const (
 
 // state struct used by dby storage
 type state struct {
-	data   []interface{}
+	data   []*interface{}
 	buffer []*interface{}
 	lib    map[string]int
 	ad     int
@@ -20,7 +20,7 @@ type state struct {
 // newStateFactory for creating a new v3 State
 func newStateFactory() *state {
 	s := state{
-		data:   make([]interface{}, 0),
+		data:   make([]*interface{}, 0),
 		buffer: make([]*interface{}, 0),
 		lib:    make(map[string]int),
 	}
@@ -31,13 +31,13 @@ func newStateFactory() *state {
 func (c *state) Clear() {
 	c.data, c.buffer, c.lib = nil, nil, nil
 
-	c.data = make([]interface{}, 0)
+	c.data = make([]*interface{}, 0)
 	c.buffer = make([]*interface{}, 0)
 	c.lib = make(map[string]int)
 }
 
-// SetAD for setting new Active Document index
-func (c *state) SetAD(i int) error {
+// setAD for setting new Active Document index
+func (c *state) setAD(i int) error {
 	if err := c.IndexInRange(i); err != nil {
 		return wrapErr(err)
 	}
@@ -52,7 +52,7 @@ func (c *state) GetAD() int {
 
 // PushData for appending data to the data array
 func (c *state) PushData(d interface{}) {
-	c.data = append(c.data, d)
+	c.data = append(c.data, &d)
 }
 
 // PushBuffer for appending data to the buffer array
@@ -61,32 +61,40 @@ func (c *state) PushBuffer(d interface{}) {
 }
 
 // GetAllData returns the data array
-func (c *state) GetAllData() []interface{} {
+func (c *state) GetAllData() []*interface{} {
 	return c.data
 }
 
 // GetAllBuffer returns the buffer array
-func (c *state) GetAllBuffer() []*interface{} {
+func (c *state) getAllBuffer() []*interface{} {
 	return c.buffer
 }
 
-// GetData returns the data in the c.ad index from the data array
-func (c *state) GetData() interface{} {
+// getData returns the data in the c.ad index from the data array
+func (c *state) getData() *interface{} {
 	data, _ := c.GetDataFromIndex(c.GetAD())
 	return data
 }
 
 // GetDataFromIndex returns the i'th element from the data array
-func (c *state) GetDataFromIndex(i int) (interface{}, error) {
+func (c *state) GetDataFromIndex(i int) (*interface{}, error) {
 	if err := c.IndexInRange(i); err != nil {
 		return nil, wrapErr(err)
 	}
 	return c.data[i], nil
 }
 
+// GetBufferFromIndex returns the i'th element from the buffer array
+func (c *state) getBufferFromIndex(i int) (*interface{}, error) {
+	if len(c.buffer)-1 >= i {
+		return c.buffer[i], nil
+	}
+	return nil, fmt.Errorf(ire)
+}
+
 // SetData sets to input value the data in the c.ad index from the data array
 func (c *state) SetData(v interface{}) error {
-	return c.SetDataFromIndex(v, c.GetAD())
+	return c.SetDataFromIndex(&v, c.GetAD())
 }
 
 // SetDataFromIndex sets to input value the i'th element from the data array
@@ -94,20 +102,12 @@ func (c *state) SetDataFromIndex(v interface{}, i int) error {
 	if err := c.IndexInRange(i); err != nil {
 		return wrapErr(err)
 	}
-	c.data[i] = v
+	c.data[i] = &v
 	return nil
 }
 
-// GetBufferFromIndex returns the i'th element from the buffer array
-func (c *state) GetBufferFromIndex(i int) (*interface{}, error) {
-	if len(c.buffer)-1 >= i {
-		return c.buffer[i], nil
-	}
-	return nil, fmt.Errorf(ire)
-}
-
 // SetDataFromIndex sets to input value the i'th element from the data array
-func (c *state) SetBufferFromIndex(v interface{}, i int) error {
+func (c *state) setBufferFromIndex(v interface{}, i int) error {
 	if len(c.buffer)-1 >= i {
 		c.buffer[i] = &v
 		return nil
@@ -158,8 +158,8 @@ func (c *state) RemoveDocName(i int) error {
 	return nil
 }
 
-// DeleteData for deleting the i'th element from the data array
-func (c *state) DeleteData(i int) error {
+// DeleteDoc for deleting the i'th element from the data array
+func (c *state) DeleteDoc(i int) error {
 	if err := c.IndexInRange(i); err != nil {
 		return wrapErr(err)
 	}
@@ -168,6 +168,7 @@ func (c *state) DeleteData(i int) error {
 		return wrapErr(err)
 	}
 
+	// We keep the order
 	c.data[i] = nil
 	c.data = append(c.data[:i], c.data[i+1:]...)
 
@@ -195,17 +196,17 @@ func (c *state) UnsetDataArray() {
 // DeleteAllData calls PurgeAllData first and then creates a new empty array
 func (c *state) DeleteAllData() {
 	c.UnsetDataArray()
-	c.data = make([]interface{}, 0)
+	c.data = make([]*interface{}, 0)
 }
 
 // UnsetBufferArray This sets buffer = nil
-func (c *state) UnsetBufferArray() {
+func (c *state) unsetBufferArray() {
 	c.buffer = nil
 }
 
 // DeleteBuffer deletes the data from the buffer array
-func (c *state) DeleteBuffer() {
-	c.UnsetBufferArray()
+func (c *state) deleteBuffer() {
+	c.unsetBufferArray()
 	c.buffer = make([]*interface{}, 0)
 }
 

--- a/db/utils.go
+++ b/db/utils.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 )
 
 func checkKeyPath(k []string) error {
@@ -15,27 +13,6 @@ func checkKeyPath(k []string) error {
 		}
 	}
 	return nil
-}
-
-func copyMap(o interface{}) (interface{}, error) {
-	obj, err := interfaceToMap(o)
-	if err != nil {
-		return nil, wrapErr(err)
-	}
-
-	var cache interface{}
-
-	data, err := yaml.Marshal(&obj)
-	if err != nil {
-		return nil, wrapErr(err)
-	}
-
-	err = yaml.Unmarshal(data, &cache)
-	if err != nil {
-		return nil, wrapErr(err)
-	}
-
-	return cache, nil
 }
 
 func emptyMap() map[interface{}]interface{} {

--- a/tests/cache_v2_test.go
+++ b/tests/cache_v2_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/likexian/gokit/assert"
+	"github.com/ulfox/dby/db"
+)
+
+// TestCacheV2 run unit tests for cachev2
+func TestCacheV2(t *testing.T) {
+	t.Parallel()
+
+	path := ".test/db-cache-v2.yaml"
+	storage, err := db.NewStorageFactory(path)
+	assert.Equal(t, err, nil)
+
+	err = storage.Upsert(
+		"test",
+		1,
+	)
+	assert.Equal(t, err, nil)
+
+	v, ok := storage.SQL.GetQCache("test")
+	assert.Equal(t, v, (*map[string]*interface{})(nil))
+	assert.Equal(t, ok, false)
+
+	val, err := storage.FindKeys("test")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val), 1)
+	assert.Equal(t, val[0], "test")
+
+	v, ok = storage.SQL.GetQCache("test")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, (*(*v)["test"]), 1)
+
+	err = storage.Delete("test")
+	assert.Equal(t, err, nil)
+
+	v, ok = storage.SQL.GetQCache("test")
+	assert.Equal(t, v, (*map[string]*interface{})(nil))
+	assert.Equal(t, ok, false)
+
+	val, err = storage.FindKeys("test")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val), 0)
+
+	err = storage.Upsert(
+		"key-1",
+		"value-1",
+	)
+	assert.Equal(t, err, nil)
+
+	err = storage.Upsert(
+		"path-1",
+		map[string]string{
+			"key-1": "value-1",
+		},
+	)
+	assert.Equal(t, err, nil)
+
+	err = storage.Upsert(
+		"path-2",
+		map[string]string{
+			"key-1": "value-1",
+		},
+	)
+	assert.Equal(t, err, nil)
+
+	_, ok = storage.SQL.GetQCache("key-1")
+	assert.Equal(t, ok, false)
+
+	val, err = storage.FindKeys("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val), 3)
+
+	v, ok = storage.SQL.GetQCache("key-1")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, (*(*v)["key-1"]), "value-1")
+	assert.Equal(t, len((*v)), 3)
+
+	err = storage.Delete("path-1.key-1")
+	assert.Equal(t, err, nil)
+
+	v, ok = storage.SQL.GetQCache("key-1")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, (*(*v)["path-2.key-1"]), "value-1")
+	assert.Equal(t, len((*v)), 2)
+
+	err = storage.Delete("key-1")
+	assert.Equal(t, err, nil)
+
+	_, ok = storage.SQL.GetQCache("key-1")
+	assert.Equal(t, ok, false)
+
+	val, err = storage.FindKeys("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val), 1)
+
+	err = os.Remove(path)
+	assert.Equal(t, err, nil)
+}
+
+// TestCacheV2Mem run unit tests for cachev2
+func TestCacheV2Mem(t *testing.T) {
+	t.Parallel()
+
+	storage, err := db.NewStorageFactory()
+	assert.Equal(t, err, nil)
+
+	err = storage.Upsert(
+		"test",
+		1,
+	)
+	assert.Equal(t, err, nil)
+
+	v, ok := storage.SQL.GetQCache("test")
+	assert.Equal(t, v, (*map[string]*interface{})(nil))
+	assert.Equal(t, ok, false)
+
+	val, err := storage.FindKeys("test")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val), 1)
+	assert.Equal(t, val[0], "test")
+
+	v, ok = storage.SQL.GetQCache("test")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, (*(*v)["test"]), 1)
+
+	err = storage.Delete("test")
+	assert.Equal(t, err, nil)
+
+	v, ok = storage.SQL.GetQCache("test")
+	assert.Equal(t, v, (*map[string]*interface{})(nil))
+	assert.Equal(t, ok, false)
+
+}

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -28,11 +28,14 @@ func TestDelete(t *testing.T) {
 	)
 
 	assert.Equal(t, err, nil)
+	val, err := storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
 
 	err = storage.Delete("test.path.key-1")
 	assert.Equal(t, err, nil)
 
-	val, err := storage.GetPath("test.path.key-1")
+	val, err = storage.GetPath("test.path.key-1")
 	assert.NotEqual(t, err, nil)
 	assert.Equal(t, val, nil)
 
@@ -42,15 +45,19 @@ func TestDelete(t *testing.T) {
 	err = storage.Upsert(
 		"key-33",
 		map[string][]string{
-			"key-5": {"value-5"},
-			"key-6": {"value-6"},
+			"key-56": {"value-5", "value-6"},
+			"key-78": {"value-7", "value-8"},
 		},
 	)
 
 	assert.Equal(t, err, nil)
-	err = storage.Delete("key-33.key-5")
+	err = storage.Delete("key-33.key-56")
 	assert.Equal(t, err, nil)
-	err = storage.Delete("key-33.key-6.[0]")
+	val, err = storage.GetPath("key-33")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(val.(map[interface{}]interface{})), 1)
+
+	err = storage.Delete("key-33.key-78.[0]")
 	assert.Equal(t, err, nil)
 
 	err = os.Remove(path)

--- a/tests/generic_test.go
+++ b/tests/generic_test.go
@@ -81,7 +81,7 @@ func TestGeneric(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, s, "v05")
 
-	keys, err := storage.Get("1")
+	keys, err := storage.FindKeys("1")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(keys), 1)
 

--- a/tests/get_first_test.go
+++ b/tests/get_first_test.go
@@ -1,14 +1,15 @@
 package tests
 
 import (
+	"os"
 	"testing"
 
 	"github.com/likexian/gokit/assert"
 	"github.com/ulfox/dby/db"
 )
 
-// TestGetFirst run unit tests on GetSingle key
-func TestGetFirst(t *testing.T) {
+// TestGetFirstMem run unit tests on GetSingle key
+func TestGetFirstMem(t *testing.T) {
 	t.Parallel()
 
 	storage, err := db.NewStorageFactory()
@@ -27,6 +28,25 @@ func TestGetFirst(t *testing.T) {
 	val, err := storage.GetFirst("key-1")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, val, "value-1")
+
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
+
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
+
+	err = storage.Upsert(
+		"key-1",
+		"value-111",
+	)
+
+	assert.Equal(t, err, nil)
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, val, "value-111")
 
 	val, err = storage.GetFirst("key-2")
 	assert.Equal(t, err, nil)
@@ -94,4 +114,116 @@ func TestGetFirst(t *testing.T) {
 	val, err = storage.GetFirst("key-30")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, val, 30)
+}
+
+// TestGetFirst run unit tests on GetSingle key
+func TestGetFirst(t *testing.T) {
+	t.Parallel()
+
+	path := ".test/db-get-first-key.yaml"
+	storage, err := db.NewStorageFactory(path)
+	assert.Equal(t, err, nil)
+
+	err = storage.Upsert(
+		"test.path",
+		map[string]string{
+			"key-1": "value-1",
+			"key-2": "value-2",
+		},
+	)
+
+	assert.Equal(t, err, nil)
+
+	val, err := storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
+
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
+
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-1")
+
+	err = storage.Upsert(
+		"key-1",
+		"value-111",
+	)
+
+	assert.Equal(t, err, nil)
+	val, err = storage.GetFirst("key-1")
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, val, "value-111")
+
+	val, err = storage.GetFirst("key-2")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, "value-2")
+
+	err = storage.Upsert(
+		"path-1",
+		map[string][]string{
+			"key-3": {"value-3"},
+			"key-4": {"value-4"},
+		},
+	)
+
+	assert.Equal(t, err, nil)
+
+	val, err = storage.GetFirst("key-3")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, []interface{}{"value-3"})
+
+	val, err = storage.GetFirst("key-4")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, []interface{}{"value-4"})
+	err = storage.Upsert(
+		"key-3",
+		map[string][]string{
+			"key-5": {"value-5"},
+			"key-6": {"value-6"},
+		},
+	)
+
+	assert.Equal(t, err, nil)
+
+	val, err = storage.GetFirst("key-3")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val.(map[interface{}]interface{})["key-5"].([]interface{})[0], "value-5")
+	assert.Equal(t, val.(map[interface{}]interface{})["key-6"].([]interface{})[0], "value-6")
+
+	err = storage.Upsert(
+		"test",
+		map[string]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = storage.Upsert(
+		"key-3",
+		map[string][]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = storage.Upsert(
+		"path-1",
+		map[string][]string{},
+	)
+	assert.Equal(t, err, nil)
+	err = storage.Upsert(
+		"to.array-10",
+		map[string][]map[string]int{
+			"key-10": {
+				{"key-20": 20},
+				{"key-30": 30},
+				{"key-40": 40},
+			},
+		},
+	)
+	assert.Equal(t, err, nil)
+
+	val, err = storage.GetFirst("key-30")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, val, 30)
+
+	err = os.Remove(path)
+	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
Fixes
- SQL/findKeys method would not proceed
  to paths that had a key already discovered

- DeleteGlobal was deleting only active document. Now it will loop
  and delete the path (if any) for all docs

- Nil input on upsert value is now translated to an empty map

Changes
- State.go: Buffer methods are no longer exported

- Cache/V2: Results are saved to v2 cache. With v2 cache we will be
  able in the next releases to implement cache like features like
  key/object TTL

- SQL: All methods now use pointers

- State: Data array now uses pointers

- GetData: Is a wrapper to getData method that returns a pointer from
  the data array.

- GetAllData: Will return the actual data array (array values are pointers)

- GetDataFromIndex: Returns a specific pointer from the data array

- Makefile: Include new target for running multiple times the tests
  this is to ensure we get always the same result and reads
  order will not alter the results